### PR TITLE
Feature anomaly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: MSstats package provide tools for preprocessing, summarization and
     processing larger than memory data sets.
 License: Artistic-2.0
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Imports: 
     arrow,
     DBI,

--- a/R/backends.R
+++ b/R/backends.R
@@ -90,7 +90,9 @@ MSstatsPreprocessBigArrow <- function(input_file,
                                       max_feature_count = 20,
                                       filter_unique_peptides = FALSE,
                                       aggregate_psms = FALSE,
-                                      filter_few_obs = FALSE) {
+                                      filter_few_obs = FALSE,
+                                      calculateAnomalyScores = FALSE, 
+                                      anomalyModelFeatures = c()) {
   input <- arrow::open_dataset(input_file, format = "csv")
   
   input <- dplyr::mutate(input,
@@ -126,10 +128,19 @@ MSstatsPreprocessBigArrow <- function(input_file,
   }
   
   if (aggregate_psms) {
-    input <- dplyr::group_by(input, ProteinName, PeptideSequence, PrecursorCharge,
-                             FragmentIon, ProductCharge, IsotopeLabelType, Run,
-                             Condition, BioReplicate)
-    input <- dplyr::summarize(input, Intensity = max(Intensity, na.rm <- TRUE))
+    group_cols <- c("ProteinName", "PeptideSequence", "PrecursorCharge",
+                    "FragmentIon", "ProductCharge", "IsotopeLabelType", "Run",
+                    "Condition", "BioReplicate")
+    
+    max_per_group <- input %>%
+      group_by(across(all_of(group_cols))) %>%
+      summarise(max_intensity = max(Intensity, na.rm = TRUE), 
+                .groups = "drop")
+    
+    filtered <- input %>%
+      inner_join(max_per_group, by = group_cols) %>%
+      filter(Intensity == max_intensity) %>%
+      select(-max_intensity)
   }
   
   if (filter_few_obs) {

--- a/R/backends.R
+++ b/R/backends.R
@@ -137,7 +137,7 @@ MSstatsPreprocessBigArrow <- function(input_file,
       summarise(max_intensity = max(Intensity, na.rm = TRUE), 
                 .groups = "drop")
     
-    filtered <- input %>%
+    input <- input %>%
       inner_join(max_per_group, by = group_cols) %>%
       filter(Intensity == max_intensity) %>%
       select(-max_intensity)

--- a/R/backends.R
+++ b/R/backends.R
@@ -144,6 +144,9 @@ MSstatsPreprocessBigArrow <- function(input_file,
   }
   
   if (filter_few_obs) {
+    input <- dplyr::mutate(input,
+                             Feature = paste(PeptideSequence, PrecursorCharge,
+                                             FragmentIon, ProductCharge, sep = "_"))
     input <- dplyr::group_by(input, ProteinName, Feature)
     observation_counts <- dplyr::summarize(input,
                                            NumObs = sum(!is.na(Intensity) &
@@ -152,6 +155,7 @@ MSstatsPreprocessBigArrow <- function(input_file,
     observation_counts <- dplyr::select(observation_counts, -NumObs)
     input <- dplyr::anti_join(input, observation_counts,
                               by = c("ProteinName", "Feature"))
+    input <- dplyr::select(input, -Feature)
   }
   
   arrow::write_csv_arrow(input, file = output_file_name)

--- a/R/clean_spectronaut.R
+++ b/R/clean_spectronaut.R
@@ -1,9 +1,12 @@
 #' @keywords internal
 reduceBigSpectronaut <- function(input_file, output_path,
+                                 intensity="F.NormalizedPeakArea",
                                  filter_by_excluded = FALSE,
                                  filter_by_identified = FALSE,
                                  filter_by_qvalue = TRUE,
-                                 qvalue_cutoff = 0.01) {
+                                 qvalue_cutoff = 0.01,
+                                 calculateAnomalyScores=FALSE, 
+                                 anomalyModelFeatures=c()) {
   if (grepl("csv", input_file)) {
     delim = ","
   } else if (grepl("tsv|xls", input_file)) {
@@ -13,11 +16,14 @@ reduceBigSpectronaut <- function(input_file, output_path,
   }
   spec_chunk <- function(x, pos) cleanSpectronautChunk(x,
                                                        output_path,
+                                                       intensity,
                                                        filter_by_excluded,
                                                        filter_by_identified,
                                                        filter_by_qvalue,
                                                        qvalue_cutoff,
-                                                       pos)
+                                                       pos,
+                                                       calculateAnomalyScores, 
+                                                       anomalyModelFeatures)
   readr::read_delim_chunked(input_file,
                             readr::DataFrameCallback$new(spec_chunk),
                             delim = delim,
@@ -26,16 +32,24 @@ reduceBigSpectronaut <- function(input_file, output_path,
 
 #' @keywords internal
 cleanSpectronautChunk = function(input, output_path,
+                                 intensity="F.NormalizedPeakArea",
                                  filter_by_excluded = FALSE,
                                  filter_by_identified = FALSE,
                                  filter_by_qvalue = TRUE,
                                  qvalue_cutoff = 0.01,
-                                 pos = NULL) {
+                                 pos = NULL,
+                                 calculateAnomalyScores=FALSE, 
+                                 anomalyModelFeatures=c()) {
   all_cols <- c("R.FileName", "R.Condition", "R.Replicate",
                 "PG.ProteinAccessions", "EG.ModifiedSequence", "FG.LabeledSequence",
                 "FG.Charge", "F.FrgIon", "F.Charge",
                 "EG.Identified", "F.ExcludedFromQuantification", "F.FrgLossType",
-                "PG.Qvalue", "EG.Qvalue", "F.NormalizedPeakArea")
+                "PG.Qvalue", "EG.Qvalue", intensity)
+  
+  if (calculateAnomalyScores){
+    all_cols <- c(all_cols, anomalyModelFeatures)
+  }
+  
   cols <- intersect(all_cols, colnames(input))
   input <- dplyr::select(input, all_of(cols))
   input <- dplyr::rename_with(input, .fn = MSstatsConvert:::.standardizeColnames)
@@ -45,6 +59,10 @@ cleanSpectronautChunk = function(input, output_path,
                  "ProductCharge", "Identified", "Excluded",
                  "FFrgLossType", "PGQvalue", "EGQvalue",
                  "Intensity")
+  if (calculateAnomalyScores){
+    new_names <- c(new_names, MSstatsConvert:::.standardizeColnames(anomalyModelFeatures))
+  }
+  
   # non_standardized =
   old_names <- MSstatsConvert:::.standardizeColnames(all_cols)
   names(old_names) <- new_names
@@ -63,30 +81,42 @@ cleanSpectronautChunk = function(input, output_path,
   }
   
   if (filter_by_excluded) {
-    input <- dplyr::filter(input, !Excluded)
-    input <- dplyr::select(input, -Excluded)
+    input <- dplyr::mutate(
+      input, Intensity = dplyr::if_else(Excluded, NA_real_, Intensity))
+    
   }
   
   if (filter_by_identified) {
-    input <- dplyr::filter(input, Identified)
-    input <- dplyr::select(input, -Identified)
+    input <- dplyr::mutate(
+      input, Intensity = dplyr::if_else(Identified, NA_real_, Intensity))
   }
   
   if (filter_by_qvalue) {
-    input <- dplyr::mutate(input, Intensity = dplyr::if_else(EGQvalue < qvalue_cutoff, Intensity, NA_real_))
-    input <- dplyr::mutate(input, Intensity = dplyr::if_else(PGQvalue < qvalue_cutoff, Intensity, NA_real_))
+    input <- dplyr::mutate(
+      input,
+      Intensity = dplyr::if_else(EGQvalue < qvalue_cutoff, Intensity, NA_real_))
+    input <- dplyr::mutate(
+      input, 
+      Intensity = dplyr::if_else(PGQvalue < qvalue_cutoff, Intensity, NA_real_))
   }
   
   input <- dplyr::filter(input, FFrgLossType == "noloss")
   if (is.element("LabeledSequence", colnames(input))) {
-    input = dplyr::mutate(input, IsLabeled = grepl("Lys8", LabeledSequence) | grepl("Arg10", LabeledSequence))
-    input = dplyr::mutate(input, IsotopeLabelType := dplyr::if_else(IsLabeled, "H", "L"))
+    input <- dplyr::mutate(input, IsLabeled = grepl("Lys8", LabeledSequence) | grepl("Arg10", LabeledSequence))
+    input <- dplyr::mutate(input, IsotopeLabelType := dplyr::if_else(IsLabeled, "H", "L"))
   } else {
     input <- dplyr::mutate(input, IsotopeLabelType = "L")
   }
-  input <- dplyr::select(input, ProteinName, PeptideSequence, PrecursorCharge, FragmentIon,
-                         ProductCharge, IsotopeLabelType, Run, BioReplicate, Condition,
-                         Intensity)
+  
+  select_cols = c("ProteinName", "PeptideSequence", "PrecursorCharge", "FragmentIon",
+                  "ProductCharge", "IsotopeLabelType", "Run", "BioReplicate", "Condition",
+                  "Intensity")
+  if (calculateAnomalyScores){
+    select_cols = c(select_cols, 
+                    MSstatsConvert:::.standardizeColnames(anomalyModelFeatures))
+  }
+  
+  input <- dplyr::select(input, select_cols)
   if (!is.null(pos)) {
     if (pos == 1) {
       readr::write_csv(input, file = output_path, append = FALSE)

--- a/R/clean_spectronaut.R
+++ b/R/clean_spectronaut.R
@@ -88,7 +88,7 @@ cleanSpectronautChunk = function(input, output_path,
   
   if (filter_by_identified) {
     input <- dplyr::mutate(
-      input, Intensity = dplyr::if_else(Identified, NA_real_, Intensity))
+      input, Intensity = dplyr::if_else(Identified, Intensity, NA_real_))
   }
   
   if (filter_by_qvalue) {

--- a/R/converters.R
+++ b/R/converters.R
@@ -136,11 +136,6 @@ bigSpectronauttoMSstatsFormat <-  function(input_file, output_file_name,
                                           remove_annotation =  FALSE,
                                           calculateAnomalyScores=FALSE, 
                                           anomalyModelFeatures=c(),
-                                          anomalyModelFeatureTemporal=c(),
-                                          runOrder=NULL, 
-                                          n_trees=100, 
-                                          max_depth="auto", 
-                                          numberOfCores=1, 
                                           connection =  NULL) {
   reduceBigSpectronaut(input_file, paste0("reduce_output_", output_file_name),
                        intensity, filter_by_excluded, filter_by_identified,
@@ -151,17 +146,6 @@ bigSpectronauttoMSstatsFormat <-  function(input_file, output_file_name,
     output_file_name, backend, max_feature_count,
     aggregate_psms, filter_few_obs, remove_annotation, calculateAnomalyScores, 
     anomalyModelFeatures, connection)
-  
-  if (calculateAnomalyScores){
-    
-    # TODO: Move this into the MSstatsAnomalyScores function
-    anomalyModelFeatures <- MSstatsConvert:::.standardizeColnames(
-      anomalyModelFeatures)
-    
-    msstats_data <- MSstatsConvert::MSstatsAnomalyScores(
-      dplyr::collect(msstats_data), anomalyModelFeatures, 
-      anomalyModelFeatureTemporal, runOrder, n_trees, max_depth, numberOfCores)
-  }
   
   return(msstats_data)
   

--- a/R/converters.R
+++ b/R/converters.R
@@ -15,6 +15,8 @@
 #' @param remove_annotation If TRUE, columns BioReplicate and Condition will be removed
 #' to reduce output file size. These will need to be added manually later before
 #' using dataProcess function. Only applicable to sparklyr backend.
+#' @param calculateAnomalyScores If TRUE, will carry anomaly model features through pipeline
+#' @param anomalyModelFeatures Character vector of column names to be carried through the pipeline
 #' @param connection Connection to a spark instance created with the
 #' `spark_connect` function from `sparklyr` package.
 #'
@@ -42,7 +44,7 @@
 MSstatsPreprocessBig <-  function(input_file,
                                  output_file_name,
                                  backend,
-                                 max_feature_count =  20,
+                                 max_feature_count =  100,
                                  filter_unique_peptides =  FALSE,
                                  aggregate_psms =  FALSE,
                                  filter_few_obs =  FALSE,
@@ -88,7 +90,7 @@ MSstatsPreprocessBig <-  function(input_file,
 #'
 bigFragPipetoMSstatsFormat <-  function(input_file, output_file_name,
                                        backend,
-                                       max_feature_count =  20,
+                                       max_feature_count =  100,
                                        filter_unique_peptides =  FALSE,
                                        aggregate_psms =  FALSE,
                                        filter_few_obs =  FALSE,
@@ -104,6 +106,7 @@ bigFragPipetoMSstatsFormat <-  function(input_file, output_file_name,
 #' Convert out-of-memory Spectronaut files to MSstats format.
 #'
 #' @inheritParams MSstatsPreprocessBig
+#' @param intensity Name of the intensity column to be used in Spectronaut
 #' @param filter_by_excluded if TRUE, will filter by the `F.ExcludedFromQuantification` column.
 #' @param filter_by_identified if TRUE, will filter by the `EG.Identified` column.
 #' @param filter_by_qvalue if TRUE, will filter by EG.Qvalue and PG.Qvalue columns.

--- a/R/converters.R
+++ b/R/converters.R
@@ -97,7 +97,7 @@ bigFragPipetoMSstatsFormat <-  function(input_file, output_file_name,
   MSstatsPreprocessBig(input_file, output_file_name,
                        backend, max_feature_count, filter_unique_peptides,
                        aggregate_psms, filter_few_obs, remove_annotation,
-                       connection)
+                       connection = connection)
 }
 
 

--- a/R/converters.R
+++ b/R/converters.R
@@ -47,6 +47,8 @@ MSstatsPreprocessBig <-  function(input_file,
                                  aggregate_psms =  FALSE,
                                  filter_few_obs =  FALSE,
                                  remove_annotation =  FALSE,
+                                 calculateAnomalyScores = FALSE, 
+                                 anomalyModelFeatures = c(),
                                  connection =  NULL) {
   if (backend == "arrow") {
     MSstatsPreprocessBigArrow(input_file,
@@ -54,7 +56,9 @@ MSstatsPreprocessBig <-  function(input_file,
                               max_feature_count,
                               filter_unique_peptides,
                               aggregate_psms,
-                              filter_few_obs)
+                              filter_few_obs,
+                              calculateAnomalyScores, 
+                              anomalyModelFeatures)
   } else if (backend == "sparklyr") {
     MSstatsPreprocessBigSparklyr(connection, input, output_file_name,
                                  max_feature_count, filter_unique_peptides,
@@ -120,23 +124,47 @@ bigFragPipetoMSstatsFormat <-  function(input_file, output_file_name,
 #'
 bigSpectronauttoMSstatsFormat <-  function(input_file, output_file_name,
                                           backend,
-                                          filter_by_excluded =  FALSE,
-                                          filter_by_identified =  FALSE,
-                                          filter_by_qvalue =  FALSE,
-                                          qvalue_cutoff =  0.01,
-                                          max_feature_count =  20,
+                                          intensity = "F.NormalizedPeakArea",
+                                          filter_by_excluded = FALSE,
+                                          filter_by_identified = FALSE,
+                                          filter_by_qvalue = FALSE,
+                                          qvalue_cutoff = 0.01,
+                                          max_feature_count = 100,
                                           filter_unique_peptides =  FALSE,
                                           aggregate_psms =  FALSE,
                                           filter_few_obs =  FALSE,
                                           remove_annotation =  FALSE,
+                                          calculateAnomalyScores=FALSE, 
+                                          anomalyModelFeatures=c(),
+                                          anomalyModelFeatureTemporal=c(),
+                                          runOrder=NULL, 
+                                          n_trees=100, 
+                                          max_depth="auto", 
+                                          numberOfCores=1, 
                                           connection =  NULL) {
   reduceBigSpectronaut(input_file, paste0("reduce_output_", output_file_name),
-                       filter_by_excluded, filter_by_identified,
-                       filter_by_qvalue, qvalue_cutoff)
-  MSstatsPreprocessBig(paste0("reduce_output_", output_file_name),
-                       output_file_name, backend, max_feature_count,
-                       aggregate_psms, filter_few_obs,
-                       remove_annotation, connection)
+                       intensity, filter_by_excluded, filter_by_identified,
+                       filter_by_qvalue, qvalue_cutoff,
+                       calculateAnomalyScores, anomalyModelFeatures)
+  msstats_data <- MSstatsPreprocessBig(
+    paste0("reduce_output_", output_file_name),
+    output_file_name, backend, max_feature_count,
+    aggregate_psms, filter_few_obs, remove_annotation, calculateAnomalyScores, 
+    anomalyModelFeatures, connection)
+  
+  if (calculateAnomalyScores){
+    
+    # TODO: Move this into the MSstatsAnomalyScores function
+    anomalyModelFeatures <- MSstatsConvert:::.standardizeColnames(
+      anomalyModelFeatures)
+    
+    msstats_data <- MSstatsConvert::MSstatsAnomalyScores(
+      dplyr::collect(msstats_data), anomalyModelFeatures, 
+      anomalyModelFeatureTemporal, runOrder, n_trees, max_depth, numberOfCores)
+  }
+  
+  return(msstats_data)
+  
 }
 
 

--- a/man/MSstatsPreprocessBig.Rd
+++ b/man/MSstatsPreprocessBig.Rd
@@ -8,11 +8,13 @@ MSstatsPreprocessBig(
   input_file,
   output_file_name,
   backend,
-  max_feature_count = 20,
+  max_feature_count = 100,
   filter_unique_peptides = FALSE,
   aggregate_psms = FALSE,
   filter_few_obs = FALSE,
   remove_annotation = FALSE,
+  calculateAnomalyScores = FALSE,
+  anomalyModelFeatures = c(),
   connection = NULL
 )
 }
@@ -39,6 +41,10 @@ Please refer to the `Details` section for additional information.}
 \item{remove_annotation}{If TRUE, columns BioReplicate and Condition will be removed
 to reduce output file size. These will need to be added manually later before
 using dataProcess function. Only applicable to sparklyr backend.}
+
+\item{calculateAnomalyScores}{If TRUE, will carry anomaly model features through pipeline}
+
+\item{anomalyModelFeatures}{Character vector of column names to be carried through the pipeline}
 
 \item{connection}{Connection to a spark instance created with the
 `spark_connect` function from `sparklyr` package.}

--- a/man/bigFragPipetoMSstatsFormat.Rd
+++ b/man/bigFragPipetoMSstatsFormat.Rd
@@ -8,7 +8,7 @@ bigFragPipetoMSstatsFormat(
   input_file,
   output_file_name,
   backend,
-  max_feature_count = 20,
+  max_feature_count = 100,
   filter_unique_peptides = FALSE,
   aggregate_psms = FALSE,
   filter_few_obs = FALSE,

--- a/man/bigSpectronauttoMSstatsFormat.Rd
+++ b/man/bigSpectronauttoMSstatsFormat.Rd
@@ -8,15 +8,18 @@ bigSpectronauttoMSstatsFormat(
   input_file,
   output_file_name,
   backend,
+  intensity = "F.NormalizedPeakArea",
   filter_by_excluded = FALSE,
   filter_by_identified = FALSE,
   filter_by_qvalue = FALSE,
   qvalue_cutoff = 0.01,
-  max_feature_count = 20,
+  max_feature_count = 100,
   filter_unique_peptides = FALSE,
   aggregate_psms = FALSE,
   filter_few_obs = FALSE,
   remove_annotation = FALSE,
+  calculateAnomalyScores = FALSE,
+  anomalyModelFeatures = c(),
   connection = NULL
 )
 }
@@ -27,6 +30,8 @@ bigSpectronauttoMSstatsFormat(
 
 \item{backend}{"arrow" or "sparklyr". Option "sparklyr" requires a spark installation
 and connection to spark instance provided in the `connection` parameter.}
+
+\item{intensity}{Name of the intensity column to be used in Spectronaut}
 
 \item{filter_by_excluded}{if TRUE, will filter by the `F.ExcludedFromQuantification` column.}
 
@@ -51,6 +56,10 @@ Please refer to the `Details` section for additional information.}
 \item{remove_annotation}{If TRUE, columns BioReplicate and Condition will be removed
 to reduce output file size. These will need to be added manually later before
 using dataProcess function. Only applicable to sparklyr backend.}
+
+\item{calculateAnomalyScores}{If TRUE, will carry anomaly model features through pipeline}
+
+\item{anomalyModelFeatures}{Character vector of column names to be carried through the pipeline}
 
 \item{connection}{Connection to a spark instance created with the
 `spark_connect` function from `sparklyr` package.}


### PR DESCRIPTION
Make MSstatsBig compatible with MSstats+. This involved allowing users to retain peak quality metrics through the process. Anomaly detection model should then be used on the output of MSstatsBig. Details on how to do this are in the MSstats+ vignette in the MSstats package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Optional anomaly scoring parameters added; pipeline can carry user-specified anomaly model features.
  - User-selectable intensity column for Spectronaut inputs.
  - Default per-protein feature selection increased from 20 to 100 in big-data workflows.

* Refactor
  - Filtering now masks intensities (preserves rows) instead of dropping them.
  - Aggregation refined to retain highest-intensity entries per group.
  - Improved parameter propagation across preprocessing and conversion pipelines.

* Documentation
  - Updated help and examples to reflect new parameters and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->