### PR TITLE
Adding annotation file param to bigDIANNtoMSstatsFormat

### DIFF
--- a/R/clean_DIANN.R
+++ b/R/clean_DIANN.R
@@ -7,13 +7,15 @@
 #' @param global_qvalue_cutoff Global Q-value cutoff
 #' @param qvalue_cutoff Q-value cutoff
 #' @param pg_qvalue_cutoff Protein group Q-value cutoff
+#' @param annotation Annotation file or data frame
 #' @return NULL. Writes to file.
 #' @keywords internal
 reduceBigDIANN <- function(input_file, output_path, MBR = TRUE,
                            quantificationColumn = "FragmentQuantCorrected",
                            global_qvalue_cutoff = 0.01,
                            qvalue_cutoff = 0.01,
-                           pg_qvalue_cutoff = 0.01) {
+                           pg_qvalue_cutoff = 0.01,
+                           annotation = NULL) {
   if (grepl("csv", input_file)) {
     delim = ","
   } else if (grepl("tsv|xls", input_file)) {
@@ -23,7 +25,7 @@ reduceBigDIANN <- function(input_file, output_path, MBR = TRUE,
   }
   
   diann_chunk <- function(x, pos) cleanDIANNChunk(x, output_path, MBR, quantificationColumn, pos,
-                     global_qvalue_cutoff, qvalue_cutoff, pg_qvalue_cutoff)
+                     global_qvalue_cutoff, qvalue_cutoff, pg_qvalue_cutoff, annotation)
 
   readr::read_delim_chunked(input_file,
                             readr::DataFrameCallback$new(diann_chunk),
@@ -41,13 +43,15 @@ reduceBigDIANN <- function(input_file, output_path, MBR = TRUE,
 #' @param global_qvalue_cutoff Global Q-value cutoff
 #' @param qvalue_cutoff Q-value cutoff
 #' @param pg_qvalue_cutoff Protein group Q-value cutoff
-#' @importFrom MSstatsConvert MSstatsImport MSstatsClean
+#' @param annotation Annotation file or data frame
+#' @importFrom MSstatsConvert MSstatsImport MSstatsClean MSstatsMakeAnnotation
 #' @return NULL
 #' @keywords internal
 cleanDIANNChunk = function(input, output_path, MBR, quantificationColumn, pos,
                            global_qvalue_cutoff = 0.01,
                            qvalue_cutoff = 0.01,
-                           pg_qvalue_cutoff = 0.01) {
+                           pg_qvalue_cutoff = 0.01,
+                           annotation = NULL) {
     input = MSstatsImport(list(input = input),
                           "MSstats", "DIANN")
     input = MSstatsClean(
@@ -58,6 +62,7 @@ cleanDIANNChunk = function(input, output_path, MBR, quantificationColumn, pos,
         qvalue_cutoff = qvalue_cutoff,
         pg_qvalue_cutoff = pg_qvalue_cutoff
     )
+    input = MSstatsMakeAnnotation(input, annotation)
     .writeChunkToFile(input, output_path, pos)
     NULL
 }

--- a/R/converters.R
+++ b/R/converters.R
@@ -166,6 +166,7 @@ bigSpectronauttoMSstatsFormat <-  function(input_file, output_file_name,
 #' into memory by using dplyr::collect function.
 #'
 bigDIANNtoMSstatsFormat <- function(input_file, 
+                                    annotation = NULL,
                                     output_file_name,
                                     backend,
                                     MBR = TRUE,
@@ -187,7 +188,7 @@ bigDIANNtoMSstatsFormat <- function(input_file,
                  paste0("reduce_output_", output_file_name),
                  MBR,
                  quantificationColumn,
-                 global_qvalue_cutoff, qvalue_cutoff, pg_qvalue_cutoff)
+                 global_qvalue_cutoff, qvalue_cutoff, pg_qvalue_cutoff, annotation)
   
   # Preprocess the cleaned data (feature selection, etc.)
   msstats_data <- MSstatsPreprocessBig(

--- a/tests/testthat/test-clean_DIANN.R
+++ b/tests/testthat/test-clean_DIANN.R
@@ -1,0 +1,39 @@
+library(testthat)
+library(mockery)
+
+context("DIANN cleaning")
+
+test_that("cleanDIANNChunk passes annotation to MSstatsMakeAnnotation", {
+  # Prepare data
+  input_chunk <- data.frame(Run = "Run1", Intensity = 100)
+  annotation <- data.frame(Run = "Run1", Condition = "A", BioReplicate = 1)
+  
+  # Mocks
+  m_import <- mock(input_chunk)
+  m_clean <- mock(input_chunk)
+  m_annotate <- mock(merge(input_chunk, annotation, by = "Run"))
+  m_write <- mock(NULL)
+  
+  stub(cleanDIANNChunk, "MSstatsImport", m_import)
+  stub(cleanDIANNChunk, "MSstatsClean", m_clean)
+  stub(cleanDIANNChunk, "MSstatsMakeAnnotation", m_annotate)
+  stub(cleanDIANNChunk, ".writeChunkToFile", m_write)
+  
+  # Execute
+  cleanDIANNChunk(input_chunk, "output.csv", MBR = TRUE, 
+                  quantificationColumn = "Intensity", pos = 1, 
+                  annotation = annotation)
+  
+  # Verify
+  expect_called(m_annotate, 1)
+  
+  # Check arguments passed to MSstatsMakeAnnotation
+  args <- mock_args(m_annotate)[[1]]
+  expect_equal(args[[1]], input_chunk) # Input from Clean
+  expect_equal(args[[2]], annotation)  # Annotation passed through
+  
+  # Check that the result of annotation is passed to write
+  expect_called(m_write, 1)
+  write_args <- mock_args(m_write)[[1]]
+  expect_equal(write_args[[1]], merge(input_chunk, annotation, by = "Run"))
+})


### PR DESCRIPTION
# Motivation and Context

 In the previous issue, we created an MSstats big converter for DIANN, but we missed captured annotation information so we are doing that in this story.
## Changes

Adding Annotation file param to bigDIANNtoMSstatsFormat

- 

## Testing
Created test-clean_DIANN.R


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The existing MSstats converter for DIANN data files did not capture annotation information. This pull request extends the DIANN conversion pipeline to support optional annotation files, enabling users to add experimental metadata (such as conditions and biological replicates) during the conversion process. The annotation capability is propagated through the chunked data processing workflow to maintain support for large out-of-memory datasets.

## Detailed Changes

**R/clean_DIANN.R**
- Added optional `annotation = NULL` parameter to `reduceBigDIANN()` function signature
- Added optional `annotation = NULL` parameter to `cleanDIANNChunk()` function signature
- Updated `diann_chunk()` nested function to pass the `annotation` parameter to `cleanDIANNChunk()`
- Added `MSstatsMakeAnnotation` to the `@importFrom MSstatsConvert` declaration in `cleanDIANNChunk()` documentation
- Added `@param annotation` documentation to both function Roxygen blocks
- Integrated `MSstatsMakeAnnotation(input, annotation)` call in `cleanDIANNChunk()` after `MSstatsClean()` to merge annotation data with cleaned DIANN data prior to file output

**R/converters.R**
- Added optional `annotation = NULL` parameter to `bigDIANNtoMSstatsFormat()` function signature, positioned after `input_file` parameter
- Updated the internal call to `reduceBigDIANN()` to include and pass through the `annotation` argument

**tests/testthat/test-clean_DIANN.R**
- Added new test file with comprehensive unit test for annotation handling
- Test constructs minimal test data including an input chunk and annotation dataframe
- Uses mockery library to stub internal functions: `MSstatsImport`, `MSstatsClean`, `MSstatsMakeAnnotation`, and `.writeChunkToFile`
- Verifies that `MSstatsMakeAnnotation` is called exactly once with correct arguments (cleaned data and annotation)
- Validates that the merged result from annotation processing is passed to the file writing function
- Ensures end-to-end data flow through the cleaning and annotation steps

## Unit Tests

A new test file `tests/testthat/test-clean_DIANN.R` was added with a single test case:
- `test_that("cleanDIANNChunk passes annotation to MSstatsMakeAnnotation")` - Verifies the annotation parameter is correctly propagated through the chunk processing pipeline using mocked dependencies and assertion checks on function call counts and arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->