### PR TITLE
Add a fallback if IsotopeLabelType is missing from dataset

### DIFF
--- a/R/clean_DIANN.R
+++ b/R/clean_DIANN.R
@@ -107,6 +107,9 @@ cleanDIANNChunk = function(input, output_path, MBR, quantificationColumn, pos,
         calculateAnomalyScores = calculateAnomalyScores,
         anomalyModelFeatures = anomalyModelFeatures
     )
+    if (!is.element("IsotopeLabelType", colnames(input))) {
+        input <- dplyr::mutate(input, IsotopeLabelType = "L")
+    }
     #input = MSstatsMakeAnnotation(input, annotation)
     .writeChunkToFile(input, output_path, pos)
     NULL


### PR DESCRIPTION
# Motivation and Context

dataProcess doesn't work if IsotopeLabelType is not a column.  Added IsotopeLabelType in the input dataset in case it's not already there.

## Changes

- Add IsotopeLabelType = "L" as a fallback in case it's not populated.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
